### PR TITLE
UrlEncodedFormEntity constructor now requires the encoding format

### DIFF
--- a/grails-app/services/com/netflix/asgard/RestClientService.groovy
+++ b/grails-app/services/com/netflix/asgard/RestClientService.groovy
@@ -225,7 +225,7 @@ class RestClientService implements InitializingBean {
         HttpPost httpPost = new HttpPost(uriPath)
         if (nameValuePairs) {
             List<NameValuePair> data = nameValuePairs.collect { new BasicNameValuePair(it.key, it.value) }
-            httpPost.setEntity(new UrlEncodedFormEntity(data))
+            httpPost.setEntity(new UrlEncodedFormEntity(data, "UTF-8"))
         }
 
         Closure marshallResponse = {


### PR DESCRIPTION
I have added UTF-8 as the default encoding for requests being sent to new relic.

@feanil @e0d PTAL.